### PR TITLE
Fixed regression in #11 with wrong packaged file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 CHANGELOG
 =========
 
+Development: v0.5.4
+-------------------
+
+Estimated release date:  Mon Jan 11 2016
+
+Update date:  Wed Dec 9 2015
+
+All changes
+
+- Fixed regression in #11 and bumped version to 0.5.3.1 for PyPi.
+
 v0.5.3
 ------
 

--- a/ninecms/__init__.py
+++ b/ninecms/__init__.py
@@ -1,5 +1,5 @@
 """ NineCMS package """
-__version__ = '0.5.3'
+__version__ = '0.5.3.1'
 __author__ = 'George Karakostas'
 __copyright__ = 'Copyright 2015, George Karakostas'
 __licence__ = 'BSD-3'


### PR DESCRIPTION
Fixed regression in #11 with wrong packaged file
Bumped version to 0.5.3.1 for PyPi